### PR TITLE
Fix type exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "version": "5.0.0",
   "description": "osu!stable version of osu!standard ruleset based on osu!lazer source code.",
   "exports": {
-    "import": "./lib/index.mjs",
-    "require": "./lib/index.cjs"
+    "import": {
+      "default": "./lib/index.mjs",
+      "types": "./lib/index.d.ts"
+    },
+    "require": {
+      "default": "./lib/index.cjs",
+      "types": "./lib/index.d.ts"
+    }
   },
   "types": "./lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Update type exports in `package.json` to support newer versions of Typescript.

This is effectively the same change that was done to `osu-classes` here: https://github.com/kionell/osu-classes/commit/a2ac80db970c2f970d759ff123f0c31b0c5f0849